### PR TITLE
Add snapshot tests for Header and SquadsScreen

### DIFF
--- a/app/(tabs)/__tests__/SquadsScreen-test.js
+++ b/app/(tabs)/__tests__/SquadsScreen-test.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import SquadsScreen from '../index';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+test('renders correctly', () => {
+  const tree = renderer.create(<SquadsScreen />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/components/__tests__/Header-test.js
+++ b/components/__tests__/Header-test.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import Header from '../Header';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+  usePathname: () => '/',
+  useNavigation: () => ({ canGoBack: () => false }),
+}));
+
+it('renders correctly', () => {
+  const tree = renderer.create(<Header />).toJSON();
+  expect(tree).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- create snapshot test for Header component
- create snapshot test for SquadsScreen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419a0eedb08332b4f3d973960a91f4