### PR TITLE
Fix native back press

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, StatusBar, Image } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, StatusBar, Image, Platform } from 'react-native';
 import { useRouter, usePathname, useNavigation } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -27,7 +27,11 @@ const Header = () => {
     router.back();
     // Force update the current path after navigation
     setTimeout(() => {
-      setCurrentPath(window.location.pathname);
+      if (Platform.OS === 'web') {
+        setCurrentPath(window.location.pathname);
+      } else {
+        setCurrentPath(pathname);
+      }
     }, 0);
   };
 

--- a/components/__tests__/Header-test.js
+++ b/components/__tests__/Header-test.js
@@ -1,15 +1,41 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
+import { Platform, TouchableOpacity } from 'react-native';
 
 import Header from '../Header';
 
+const backMock = jest.fn();
+const canGoBackMock = jest.fn();
+const pathnameMock = jest.fn();
+
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ back: jest.fn() }),
-  usePathname: () => '/',
-  useNavigation: () => ({ canGoBack: () => false }),
+  useRouter: () => ({ back: backMock }),
+  usePathname: pathnameMock,
+  useNavigation: () => ({ canGoBack: canGoBackMock }),
 }));
 
 it('renders correctly', () => {
+  pathnameMock.mockReturnValue('/');
+  canGoBackMock.mockReturnValue(false);
   const tree = renderer.create(<Header />).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+it('does not crash on non-web platforms', () => {
+  pathnameMock.mockReturnValue('/other');
+  canGoBackMock.mockReturnValue(true);
+  const originalPlatform = Platform.OS;
+  Platform.OS = 'android';
+  const originalWindow = global.window;
+  // Simulate absence of window like in native environments
+  // @ts-ignore
+  delete global.window;
+
+  const tree = renderer.create(<Header />);
+  const button = tree.root.findByType(TouchableOpacity);
+  expect(() => button.props.onPress()).not.toThrow();
+
+  // Restore mocks
+  Platform.OS = originalPlatform;
+  global.window = originalWindow;
 });


### PR DESCRIPTION
## Summary
- handleBackPress checks Platform.OS before reading `window.location`
- add missing Platform import
- test native behaviour by mocking Platform.OS

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842d76a93908332ac58eb324fbd85da