### PR TITLE
Add user profile onboarding modal

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,15 +1,45 @@
 import { StatusBar } from 'expo-status-bar';
 import { Platform, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
 
 import EditScreenInfo from '@/components/EditScreenInfo';
 import { Text, View } from '@/components/Themed';
 
+interface ProfileData {
+  name: string;
+  location: string;
+  primaryPosition: string;
+  secondaryPosition: string;
+}
+
 export default function ProfileScreen() {
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      const data = await SecureStore.getItemAsync('userProfile');
+      if (data) {
+        setProfile(JSON.parse(data));
+      }
+    };
+    loadProfile();
+  }, []);
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Profile</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-      <Text>Your profile information will appear here.</Text>
+      {profile ? (
+        <>
+          <Text style={styles.info}>Name: {profile.name}</Text>
+          <Text style={styles.info}>Location: {profile.location}</Text>
+          <Text style={styles.info}>Primary Position: {profile.primaryPosition}</Text>
+          <Text style={styles.info}>Secondary Position: {profile.secondaryPosition}</Text>
+        </>
+      ) : (
+        <Text>Your profile information will appear here.</Text>
+      )}
       <EditScreenInfo path="/app/(tabs)/profile.tsx" />
       <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
     </View>
@@ -30,5 +60,9 @@ const styles = StyleSheet.create({
     marginVertical: 30,
     height: 1,
     width: '80%',
+  },
+  info: {
+    fontSize: 16,
+    marginBottom: 6,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,13 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import Header from '@/components/Header';
+import UserProfileModal from '@/components/UserProfileModal';
 
 export default function RootLayout() {
   return (
     <>
       <StatusBar style="light" backgroundColor="#1a1a2e" />
+      <UserProfileModal />
       <Stack
         screenOptions={{
           header: () => <Header />,

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+interface ProfileData {
+  name: string;
+  location: string;
+  primaryPosition: string;
+  secondaryPosition: string;
+}
+
+const positions = ['GK','CB','RB','LB','CDM','CM','CAM','RW','LW','ST'];
+
+export default function UserProfileModal() {
+  const [visible, setVisible] = useState(false);
+  const [name, setName] = useState('');
+  const [location, setLocation] = useState('');
+  const [primary, setPrimary] = useState('');
+  const [secondary, setSecondary] = useState('');
+
+  useEffect(() => {
+    const checkProfile = async () => {
+      const data = await SecureStore.getItemAsync('userProfile');
+      if (!data) {
+        setVisible(true);
+      }
+    };
+    checkProfile();
+  }, []);
+
+  const saveProfile = async () => {
+    const profile: ProfileData = {
+      name,
+      location,
+      primaryPosition: primary,
+      secondaryPosition: secondary,
+    };
+    await SecureStore.setItemAsync('userProfile', JSON.stringify(profile));
+    setVisible(false);
+  };
+
+  const renderPositions = (
+    value: string,
+    setValue: React.Dispatch<React.SetStateAction<string>>,
+  ) => (
+    <View style={styles.positionGrid}>
+      {positions.map((pos) => (
+        <TouchableOpacity
+          key={pos}
+          style={[
+            styles.positionItem,
+            value === pos && styles.selectedPosition,
+          ]}
+          onPress={() => setValue(pos)}
+        >
+          <Text style={styles.positionText}>{pos}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.overlay}>
+        <ScrollView contentContainerStyle={styles.modalContent}>
+          <Text style={styles.title}>Welcome! Tell us about you</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Name"
+            placeholderTextColor="#888"
+            value={name}
+            onChangeText={setName}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Location"
+            placeholderTextColor="#888"
+            value={location}
+            onChangeText={setLocation}
+          />
+          <Text style={styles.sectionTitle}>Primary Position</Text>
+          {renderPositions(primary, setPrimary)}
+          <Text style={styles.sectionTitle}>Secondary Position</Text>
+          {renderPositions(secondary, setSecondary)}
+          <TouchableOpacity style={styles.saveButton} onPress={saveProfile}>
+            <Text style={styles.saveButtonText}>Save</Text>
+          </TouchableOpacity>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  modalContent: {
+    backgroundColor: '#1a1a2e',
+    borderRadius: 16,
+    padding: 24,
+    width: '100%',
+    maxWidth: 400,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  input: {
+    backgroundColor: '#0f0f23',
+    color: '#fff',
+    borderRadius: 12,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#333',
+  },
+  sectionTitle: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginTop: 10,
+    marginBottom: 8,
+  },
+  positionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  positionItem: {
+    borderWidth: 1,
+    borderColor: '#4CAF50',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    margin: 4,
+  },
+  selectedPosition: {
+    backgroundColor: '#4CAF50',
+  },
+  positionText: {
+    color: '#fff',
+    fontSize: 14,
+  },
+  saveButton: {
+    backgroundColor: '#4CAF50',
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  saveButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-router": "~5.0.6",
     "expo-splash-screen": "~0.30.8",
     "expo-status-bar": "~2.2.3",
+    "expo-secure-store": "~12.4.0",
     "expo-system-ui": "~5.0.7",
     "expo-web-browser": "~14.1.6",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- capture user details with a popup on first launch
- save profile data using Expo Secure Store
- show saved data on the Profile screen

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe75a21083328c6b9e3bbd8e373c