### PR TITLE
Add shared user profile context

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,30 +1,13 @@
 import { StatusBar } from 'expo-status-bar';
 import { Platform, StyleSheet } from 'react-native';
-import React, { useEffect, useState } from 'react';
-import * as SecureStore from 'expo-secure-store';
+import React from 'react';
+import { useUserProfile } from '@/components/UserProfileContext';
 
 import EditScreenInfo from '@/components/EditScreenInfo';
 import { Text, View } from '@/components/Themed';
 
-interface ProfileData {
-  name: string;
-  location: string;
-  primaryPosition: string;
-  secondaryPosition: string;
-}
-
 export default function ProfileScreen() {
-  const [profile, setProfile] = useState<ProfileData | null>(null);
-
-  useEffect(() => {
-    const loadProfile = async () => {
-      const data = await SecureStore.getItemAsync('userProfile');
-      if (data) {
-        setProfile(JSON.parse(data));
-      }
-    };
-    loadProfile();
-  }, []);
+  const { profile } = useUserProfile();
 
   return (
     <View style={styles.container}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,10 +2,11 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import Header from '@/components/Header';
 import UserProfileModal from '@/components/UserProfileModal';
+import { UserProfileProvider } from '@/components/UserProfileContext';
 
 export default function RootLayout() {
   return (
-    <>
+    <UserProfileProvider>
       <StatusBar style="light" backgroundColor="#1a1a2e" />
       <UserProfileModal />
       <Stack
@@ -18,6 +19,6 @@ export default function RootLayout() {
       >
         <Stack.Screen name="(tabs)" options={{ headerShown: true }} />
       </Stack>
-    </>
+    </UserProfileProvider>
   );
 }

--- a/components/UserProfileContext.tsx
+++ b/components/UserProfileContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
+
+export interface ProfileData {
+  name: string;
+  location: string;
+  primaryPosition: string;
+  secondaryPosition: string;
+}
+
+interface UserProfileContextValue {
+  profile: ProfileData | null;
+  saveProfile: (data: ProfileData) => Promise<void>;
+}
+
+const UserProfileContext = createContext<UserProfileContextValue>({
+  profile: null,
+  saveProfile: async () => {},
+});
+
+export function UserProfileProvider({ children }: { children: React.ReactNode }) {
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await SecureStore.getItemAsync('userProfile');
+      if (stored) {
+        setProfile(JSON.parse(stored));
+      }
+    })();
+  }, []);
+
+  const saveProfile = async (data: ProfileData) => {
+    await SecureStore.setItemAsync('userProfile', JSON.stringify(data));
+    setProfile(data);
+  };
+
+  return (
+    <UserProfileContext.Provider value={{ profile, saveProfile }}>
+      {children}
+    </UserProfileContext.Provider>
+  );
+}
+
+export function useUserProfile() {
+  return useContext(UserProfileContext);
+}

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -8,18 +8,13 @@ import {
   StyleSheet,
   ScrollView,
 } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
+import { useUserProfile, ProfileData } from './UserProfileContext';
 
-interface ProfileData {
-  name: string;
-  location: string;
-  primaryPosition: string;
-  secondaryPosition: string;
-}
 
 const positions = ['GK','CB','RB','LB','CDM','CM','CAM','RW','LW','ST'];
 
 export default function UserProfileModal() {
+  const { profile, saveProfile: persistProfile } = useUserProfile();
   const [visible, setVisible] = useState(false);
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
@@ -27,23 +22,19 @@ export default function UserProfileModal() {
   const [secondary, setSecondary] = useState('');
 
   useEffect(() => {
-    const checkProfile = async () => {
-      const data = await SecureStore.getItemAsync('userProfile');
-      if (!data) {
-        setVisible(true);
-      }
-    };
-    checkProfile();
-  }, []);
+    if (!profile) {
+      setVisible(true);
+    }
+  }, [profile]);
 
   const saveProfile = async () => {
-    const profile: ProfileData = {
+    const data: ProfileData = {
       name,
       location,
       primaryPosition: primary,
       secondaryPosition: secondary,
     };
-    await SecureStore.setItemAsync('userProfile', JSON.stringify(profile));
+    await persistProfile(data);
     setVisible(false);
   };
 


### PR DESCRIPTION
## Summary
- create `UserProfileContext` for loading and saving profile info
- show `UserProfileModal` based on context state
- expose profile data via the new context on the profile screen
- wrap the app in `UserProfileProvider`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684624f18d1c8332a569ff862b0715b2