### PR TITLE
Add availability toggle on home page squads

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -42,6 +42,11 @@ export default function SquadsScreen() {
 
   const [modalVisible, setModalVisible] = useState(false);
   const [newSquadName, setNewSquadName] = useState('');
+  const [availability, setAvailability] = useState<Record<string, boolean>>({});
+
+  const toggleAvailability = (squadId: string) => {
+    setAvailability((prev) => ({ ...prev, [squadId]: !prev[squadId] }));
+  };
 
   const handleCreateSquad = () => {
     if (newSquadName.trim()) {
@@ -138,6 +143,14 @@ export default function SquadsScreen() {
                 <View style={styles.squadActions}>
                   <TouchableOpacity style={styles.actionButton}>
                     <Text style={styles.actionButtonText}>View Details</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.availabilityButton]}
+                    onPress={() => toggleAvailability(squad.id)}
+                  >
+                    <Text style={styles.actionButtonText}>
+                      {availability[squad.id] ? 'Available' : 'Set Availability'}
+                    </Text>
                   </TouchableOpacity>
                 </View>
               </TouchableOpacity>
@@ -330,6 +343,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderRadius: 8,
+  },
+  availabilityButton: {
+    backgroundColor: '#2196F3',
+    marginLeft: 10,
   },
   actionButtonText: {
     color: '#fff',


### PR DESCRIPTION
## Summary
- allow toggling fixture availability on each squad card from the home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684785143f8c8332abcc48de8adde22f