### PR TITLE
Add availability toggle on home page squads

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import AvailabilityToggle from '../../components/AvailabilityToggle';
 
 interface Squad {
   id: string;
@@ -42,6 +43,11 @@ export default function SquadsScreen() {
 
   const [modalVisible, setModalVisible] = useState(false);
   const [newSquadName, setNewSquadName] = useState('');
+  const [availability, setAvailability] = useState<Record<string, boolean>>({});
+
+  const toggleAvailability = (squadId: string) => {
+    setAvailability((prev) => ({ ...prev, [squadId]: !prev[squadId] }));
+  };
 
   const handleCreateSquad = () => {
     if (newSquadName.trim()) {
@@ -139,6 +145,12 @@ export default function SquadsScreen() {
                   <TouchableOpacity style={styles.actionButton}>
                     <Text style={styles.actionButtonText}>View Details</Text>
                   </TouchableOpacity>
+                  <View style={styles.availabilityWrapper}>
+                    <AvailabilityToggle
+                      available={!!availability[squad.id]}
+                      onToggle={() => toggleAvailability(squad.id)}
+                    />
+                  </View>
                 </View>
               </TouchableOpacity>
             ))}
@@ -330,6 +342,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderRadius: 8,
+  },
+  availabilityWrapper: {
+    marginLeft: 10,
   },
   actionButtonText: {
     color: '#fff',

--- a/components/AvailabilityToggle.tsx
+++ b/components/AvailabilityToggle.tsx
@@ -1,0 +1,51 @@
+import React, { useRef } from 'react';
+import { Animated, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface Props {
+  available: boolean;
+  onToggle: () => void;
+}
+
+export default function AvailabilityToggle({ available, onToggle }: Props) {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  const handlePress = () => {
+    Animated.sequence([
+      Animated.timing(scale, {
+        toValue: 0.8,
+        duration: 100,
+        useNativeDriver: true,
+      }),
+      Animated.spring(scale, {
+        toValue: 1,
+        useNativeDriver: true,
+      }),
+    ]).start();
+    onToggle();
+  };
+
+  const backgroundColor = available ? '#4CAF50' : '#F44336';
+  const icon = available ? 'checkmark' : 'close';
+
+  return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor }]}
+        onPress={handlePress}
+      >
+        <Ionicons name={icon} size={20} color="#fff" />
+      </TouchableOpacity>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add animated toggle icon for squad availability
- replace text availability button with new icon in Home page squads

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684785143f8c8332abcc48de8adde22f