### PR TITLE
Implement square availability toggles

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -45,8 +45,8 @@ export default function SquadsScreen() {
   const [newSquadName, setNewSquadName] = useState('');
   const [availability, setAvailability] = useState<Record<string, boolean>>({});
 
-  const toggleAvailability = (squadId: string) => {
-    setAvailability((prev) => ({ ...prev, [squadId]: !prev[squadId] }));
+  const setSquadAvailability = (squadId: string, value: boolean) => {
+    setAvailability((prev) => ({ ...prev, [squadId]: value }));
   };
 
   const handleCreateSquad = () => {
@@ -148,7 +148,7 @@ export default function SquadsScreen() {
                   <View style={styles.availabilityWrapper}>
                     <AvailabilityToggle
                       available={!!availability[squad.id]}
-                      onToggle={() => toggleAvailability(squad.id)}
+                      onToggle={(value) => setSquadAvailability(squad.id, value)}
                     />
                   </View>
                 </View>
@@ -343,8 +343,8 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 8,
   },
-  availabilityButton: {
-    backgroundColor: '#2196F3',
+  availabilityWrapper: {
+    flexDirection: 'row',
     marginLeft: 10,
   },
   actionButtonText: {

--- a/components/AvailabilityToggle.tsx
+++ b/components/AvailabilityToggle.tsx
@@ -1,51 +1,64 @@
-import React, { useRef } from 'react';
-import { Animated, StyleSheet, TouchableOpacity } from 'react-native';
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 interface Props {
   available: boolean;
-  onToggle: () => void;
+  onToggle: (value: boolean) => void;
 }
 
 export default function AvailabilityToggle({ available, onToggle }: Props) {
-  const scale = useRef(new Animated.Value(1)).current;
-
-  const handlePress = () => {
-    Animated.sequence([
-      Animated.timing(scale, {
-        toValue: 0.8,
-        duration: 100,
-        useNativeDriver: true,
-      }),
-      Animated.spring(scale, {
-        toValue: 1,
-        useNativeDriver: true,
-      }),
-    ]).start();
-    onToggle();
-  };
-
-  const backgroundColor = available ? '#4CAF50' : '#F44336';
-  const icon = available ? 'checkmark' : 'close';
-
   return (
-    <Animated.View style={{ transform: [{ scale }] }}>
+    <View style={styles.container}>
       <TouchableOpacity
-        style={[styles.button, { backgroundColor }]}
-        onPress={handlePress}
+        style={[
+          styles.button,
+          available ? styles.available : styles.unselected,
+        ]}
+        onPress={() => onToggle(true)}
       >
-        <Ionicons name={icon} size={20} color="#fff" />
+        <Ionicons
+          name="checkmark"
+          size={20}
+          color={available ? '#fff' : '#4CAF50'}
+        />
       </TouchableOpacity>
-    </Animated.View>
+      <TouchableOpacity
+        style={[
+          styles.button,
+          !available ? styles.unavailable : styles.unselected,
+        ]}
+        onPress={() => onToggle(false)}
+      >
+        <Ionicons
+          name="close"
+          size={20}
+          color={!available ? '#fff' : '#F44336'}
+        />
+      </TouchableOpacity>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
   button: {
     width: 36,
     height: 36,
-    borderRadius: 18,
+    borderRadius: 4,
     justifyContent: 'center',
     alignItems: 'center',
+    marginHorizontal: 2,
+  },
+  available: {
+    backgroundColor: '#4CAF50',
+  },
+  unavailable: {
+    backgroundColor: '#F44336',
+  },
+  unselected: {
+    backgroundColor: '#333',
   },
 });


### PR DESCRIPTION
## Summary
- show tick and cross options simultaneously
- highlight the active value
- make availability buttons square

## Testing
- `npm test` *(fails: `npm` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479109cbbc8332be3b23bf1b9b7f5b