### PR TITLE
Add formation board screen

### DIFF
--- a/app/squad/[id]/index.tsx
+++ b/app/squad/[id]/index.tsx
@@ -1,58 +1,96 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
-
-interface Fixture {
-  id: string;
-  opponent: string;
-  date: string;
-}
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import FormationBoard, { Player } from '@/components/FormationBoard';
+import DraggablePlayer from '@/components/DraggablePlayer';
 
 export default function SquadScreen() {
   const { id } = useLocalSearchParams();
-  const router = useRouter();
 
-  const [fixtures] = useState<Fixture[]>([
-    { id: '1', opponent: 'Rivals FC', date: 'July 20, 2024' },
-    { id: '2', opponent: 'United FC', date: 'July 27, 2024' },
-  ]);
+  const samplePlayers: Player[] = [
+    { id: '1', name: 'John Doe', games: 10, goals: 4, assists: 2 },
+    { id: '2', name: 'Jane Smith', games: 8, goals: 2, assists: 5 },
+    { id: '3', name: 'Alex Johnson', games: 6, goals: 3, assists: 1 },
+    { id: '4', name: 'Sam Lee', games: 9, goals: 5, assists: 3 },
+    { id: '5', name: 'Chris Paul', games: 7, goals: 1, assists: 4 },
+    { id: '6', name: 'Taylor Ray', games: 5, goals: 0, assists: 2 },
+    { id: '7', name: 'Jordan Bass', games: 4, goals: 2, assists: 1 },
+    { id: '8', name: 'Pat Green', games: 3, goals: 1, assists: 0 },
+    { id: '9', name: 'Morgan Cole', games: 2, goals: 0, assists: 0 },
+    { id: '10', name: 'Jamie Fox', games: 1, goals: 0, assists: 0 },
+    { id: '11', name: 'Riley Dean', games: 0, goals: 0, assists: 0 },
+  ];
 
-  const [availability, setAvailability] = useState<Record<string, boolean>>({});
+  const [playerCount, setPlayerCount] = useState(5);
+  const [availablePlayers, setAvailablePlayers] = useState<Player[]>(samplePlayers);
+  const [slots, setSlots] = useState<(Player | null)[]>(Array(playerCount).fill(null));
+  const [boardLayout, setBoardLayout] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
 
-  const toggleAvailability = (fixtureId: string) => {
-    setAvailability((prev) => ({ ...prev, [fixtureId]: !prev[fixtureId] }));
+  const changePlayerCount = (count: number) => {
+    const newCount = Math.min(11, Math.max(5, count));
+    setPlayerCount(newCount);
+    setSlots((prev) => {
+      const updated = [...prev];
+      if (updated.length > newCount) updated.length = newCount;
+      while (updated.length < newCount) updated.push(null);
+      return updated;
+    });
+  };
+
+  const handleDrop = (player: Player, pos: { x: number; y: number }) => {
+    if (!boardLayout) return;
+    if (
+      pos.x >= boardLayout.x &&
+      pos.x <= boardLayout.x + boardLayout.width &&
+      pos.y >= boardLayout.y &&
+      pos.y <= boardLayout.y + boardLayout.height
+    ) {
+      const index = slots.findIndex((s) => s === null);
+      if (index !== -1) {
+        const updatedSlots = [...slots];
+        updatedSlots[index] = player;
+        setSlots(updatedSlots);
+        setAvailablePlayers((prev) => prev.filter((p) => p.id !== player.id));
+      }
+    }
+  };
+
+  const autoAssign = () => {
+    const openIndices = slots.map((p, i) => (p ? -1 : i)).filter((i) => i !== -1) as number[];
+    const toAssign = availablePlayers.slice(0, openIndices.length);
+    const updatedSlots = [...slots];
+    toAssign.forEach((p, idx) => {
+      updatedSlots[openIndices[idx]] = p;
+    });
+    setSlots(updatedSlots);
+    setAvailablePlayers((prev) => prev.filter((p) => !toAssign.includes(p)));
   };
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Squad {id}</Text>
 
-      <FlatList
-        data={fixtures}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.fixtureCard}>
-            <Text style={styles.fixtureText}>
-              {item.date} vs {item.opponent}
-            </Text>
-            <TouchableOpacity
-              style={styles.availabilityButton}
-              onPress={() => toggleAvailability(item.id)}
-            >
-              <Text style={styles.availabilityButtonText}>
-                {availability[item.id] ? 'Available' : 'Set Availability'}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        )}
-        contentContainerStyle={styles.fixtureList}
-      />
+      <View style={styles.controls}>
+        <TouchableOpacity style={styles.countButton} onPress={() => changePlayerCount(playerCount - 1)}>
+          <Text style={styles.countText}>-</Text>
+        </TouchableOpacity>
+        <Text style={styles.countLabel}>{playerCount} Players</Text>
+        <TouchableOpacity style={styles.countButton} onPress={() => changePlayerCount(playerCount + 1)}>
+          <Text style={styles.countText}>+</Text>
+        </TouchableOpacity>
+      </View>
 
-      <TouchableOpacity
-        style={styles.playersButton}
-        onPress={() => router.push({ pathname: '/squad/[id]/players', params: { id } })}
-      >
-        <Text style={styles.playersButtonText}>View Players</Text>
+      <FormationBoard slots={slots} onLayout={(e) => setBoardLayout(e.nativeEvent.layout)} />
+
+      <Text style={styles.subtitle}>Available Players</Text>
+      <View style={styles.availableList}>
+        {availablePlayers.map((p) => (
+          <DraggablePlayer key={p.id} player={p} onDrop={handleDrop} />
+        ))}
+      </View>
+
+      <TouchableOpacity style={styles.autoButton} onPress={autoAssign}>
+        <Text style={styles.autoButtonText}>Auto Assign</Text>
       </TouchableOpacity>
     </View>
   );
@@ -70,37 +108,45 @@ const styles = StyleSheet.create({
     color: '#fff',
     marginBottom: 16,
   },
-  fixtureList: {
-    paddingBottom: 20,
-  },
-  fixtureCard: {
-    backgroundColor: '#1a1a2e',
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 12,
-  },
-  fixtureText: {
-    color: '#fff',
-    marginBottom: 8,
-  },
-  availabilityButton: {
-    backgroundColor: '#4CAF50',
-    paddingVertical: 8,
-    borderRadius: 8,
+  controls: {
+    flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
   },
-  availabilityButtonText: {
+  countButton: {
+    backgroundColor: '#1a1a2e',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    marginHorizontal: 8,
+  },
+  countText: {
     color: '#fff',
+    fontSize: 18,
     fontWeight: 'bold',
   },
-  playersButton: {
+  countLabel: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  subtitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  availableList: {
+    paddingHorizontal: 20,
+  },
+  autoButton: {
     backgroundColor: '#2196F3',
     paddingVertical: 12,
     borderRadius: 12,
     alignItems: 'center',
     marginTop: 20,
   },
-  playersButtonText: {
+  autoButtonText: {
     color: '#fff',
     fontWeight: 'bold',
     fontSize: 16,

--- a/components/DraggablePlayer.tsx
+++ b/components/DraggablePlayer.tsx
@@ -1,0 +1,49 @@
+import React, { useRef } from 'react';
+import { Animated, PanResponder, Text, StyleSheet } from 'react-native';
+import { Player } from './FormationBoard';
+
+interface Props {
+  player: Player;
+  onDrop: (player: Player, pos: { x: number; y: number }) => void;
+}
+
+const DraggablePlayer: React.FC<Props> = ({ player, onDrop }) => {
+  const pan = useRef(new Animated.ValueXY()).current;
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderMove: Animated.event([null, { dx: pan.x, dy: pan.y }], {
+        useNativeDriver: false,
+      }),
+      onPanResponderRelease: (_, gesture) => {
+        onDrop(player, { x: gesture.moveX, y: gesture.moveY });
+        Animated.timing(pan, {
+          toValue: { x: 0, y: 0 },
+          duration: 200,
+          useNativeDriver: false,
+        }).start();
+      },
+    })
+  ).current;
+
+  return (
+    <Animated.View style={[styles.player, pan.getLayout()]} {...panResponder.panHandlers}>
+      <Text style={styles.text}>{player.name}</Text>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  player: {
+    backgroundColor: '#4CAF50',
+    padding: 8,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  text: {
+    color: '#fff',
+  },
+});
+
+export default DraggablePlayer;

--- a/components/FormationBoard.tsx
+++ b/components/FormationBoard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export interface Player {
+  id: string;
+  name: string;
+  games: number;
+  goals: number;
+  assists: number;
+  position?: string;
+}
+
+interface FormationBoardProps {
+  slots: (Player | null)[];
+  onLayout?: (layout: any) => void;
+}
+
+const FormationBoard: React.FC<FormationBoardProps> = ({ slots, onLayout }) => {
+  return (
+    <View style={styles.board} onLayout={onLayout}>
+      {slots.map((player, index) => (
+        <View key={index} style={styles.slot}>
+          {player ? (
+            <Text style={styles.slotText}>{player.name}</Text>
+          ) : (
+            <Text style={styles.slotText}>Slot {index + 1}</Text>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  board: {
+    backgroundColor: '#0f0f23',
+    padding: 10,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    borderRadius: 12,
+    marginBottom: 20,
+  },
+  slot: {
+    width: '22%',
+    height: 60,
+    backgroundColor: '#1a1a2e',
+    margin: 4,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  slotText: {
+    color: '#fff',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+});
+
+export default FormationBoard;


### PR DESCRIPTION
## Summary
- revamp squad screen with a formation board
- add draggable player component for simple drag/drop
- list available players below board and auto-assign

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff465f0c8332ad6c78466e6c3b36