### PR TITLE
Add home/away toggle and condensed FormationPicker

### DIFF
--- a/app/squad/[id]/index.tsx
+++ b/app/squad/[id]/index.tsx
@@ -3,20 +3,56 @@ import {
   ScrollView,
   Text,
   StyleSheet,
+  Pressable,
+  View,
 } from 'react-native';
-import FormationPicker from '@/components/FormationPicker';
+import FormationPicker, { Player, Position, initialPlayers, initialPositions } from '@/components/FormationPicker';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function SquadScreen() {
   const params = useLocalSearchParams();
-  const squadId = Array.isArray(params.id) ? params.id[0] : params.id;  const router = useRouter();
+  const squadId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const router = useRouter();
+
+  const [activeTeam, setActiveTeam] = useState<'Home' | 'Away'>('Home');
+  const [homeData, setHomeData] = useState({ players: initialPlayers, positions: initialPositions });
+  const [awayData, setAwayData] = useState({ players: initialPlayers, positions: initialPositions });
+
+  const handleChange = (data: { players: Player[]; positions: Position[] }) => {
+    if (activeTeam === 'Home') {
+      setHomeData(data);
+    } else {
+      setAwayData(data);
+    }
+  };
+
+  const currentData = activeTeam === 'Home' ? homeData : awayData;
 
   return (
-    <ScrollView 
+    <ScrollView
       contentContainerStyle={styles.container}
       showsVerticalScrollIndicator={false}
     >
-      <Text style={styles.title}>Squad {squadId}</Text>      <FormationPicker />
+      <Text style={styles.title}>Squad {squadId}</Text>
+      <View style={styles.toggleContainer}>
+        <Pressable
+          onPress={() => setActiveTeam('Home')}
+          style={[styles.toggleButton, activeTeam === 'Home' && styles.toggleButtonActive]}
+        >
+          <Text style={[styles.toggleText, activeTeam === 'Home' && styles.toggleTextActive]}>Home</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setActiveTeam('Away')}
+          style={[styles.toggleButton, activeTeam === 'Away' && styles.toggleButtonActive]}
+        >
+          <Text style={[styles.toggleText, activeTeam === 'Away' && styles.toggleTextActive]}>Away</Text>
+        </Pressable>
+      </View>
+      <FormationPicker
+        players={currentData.players}
+        positions={currentData.positions}
+        onChange={handleChange}
+      />
     </ScrollView>
   );
 }
@@ -32,5 +68,29 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#fff',
     marginBottom: 16,
-  },  // Removed unused styles
+  },
+  toggleContainer: {
+    flexDirection: 'row',
+    alignSelf: 'center',
+    marginBottom: 16,
+    borderRadius: 4,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: '#fff',
+  },
+  toggleButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 20,
+    backgroundColor: 'transparent',
+  },
+  toggleButtonActive: {
+    backgroundColor: '#fff',
+  },
+  toggleText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  toggleTextActive: {
+    color: '#08111c',
+  },
 });

--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, Platform, Pressable } from 'react-native';
 
 const POSITION_SIZE = 40;
 
 // Types
-interface Player {
+export interface Player {
   id: string;
   number: string;
   color?: string;
   name: string;
 }
 
-interface Position {
+export interface Position {
   id: PositionId;
   x: number;
   y: number;
@@ -21,7 +21,7 @@ interface Position {
 
 type PositionId = 'GK' | 'LB' | 'LCB' | 'RCB' | 'RB' | 'DM' | 'LM' | 'RM' | 'AM' | 'CF1' | 'CF2';
 
-const initialPlayers: Player[] = [
+export const initialPlayers: Player[] = [
   { id: '1', name: 'Player 1', number: '1' },
   { id: '2', name: 'Player 2', number: '2' },
   { id: '3', name: 'Player 3', number: '3' },
@@ -35,7 +35,7 @@ const initialPlayers: Player[] = [
   { id: '11', name: 'Player 11', number: '11' },
 ];
 
-const initialPositions: Position[] = [
+export const initialPositions: Position[] = [
   { id: 'GK', label: 'GK', x: 50, y: 90 },
   { id: 'LB', label: 'LB', x: 20, y: 70 },
   { id: 'LCB', label: 'CB', x: 35, y: 70 },
@@ -56,9 +56,24 @@ interface PlayerDotProps {
   onPress: () => void;
 }
 
-export default function FormationPicker() {
-  const [players, setPlayers] = useState<Player[]>(initialPlayers);
-  const [positions, setPositions] = useState<Position[]>(initialPositions);
+export interface FormationPickerProps {
+  players?: Player[];
+  positions?: Position[];
+  onChange?: (data: { players: Player[]; positions: Position[] }) => void;
+}
+
+export default function FormationPicker({ players: playersProp, positions: positionsProp, onChange }: FormationPickerProps) {
+  const [players, setPlayers] = useState<Player[]>(playersProp ?? initialPlayers);
+  const [positions, setPositions] = useState<Position[]>(positionsProp ?? initialPositions);
+  useEffect(() => {
+    if (playersProp) setPlayers(playersProp);
+  }, [playersProp]);
+  useEffect(() => {
+    if (positionsProp) setPositions(positionsProp);
+  }, [positionsProp]);
+  useEffect(() => {
+    onChange?.({ players, positions });
+  }, [players, positions, onChange]);
   const [selectedPlayer, setSelectedPlayer] = useState<{ player: Player, fromPosition?: Position } | null>(null);
 
   const handlePositionPress = (position: Position) => {
@@ -131,7 +146,7 @@ export default function FormationPicker() {
         } : {},
       ]}
     >
-      <Text style={styles.playerText}>{player.number}</Text>
+      <Text style={styles.playerText}>{player.name}</Text>
     </Pressable>
   );
 
@@ -191,7 +206,7 @@ const styles = StyleSheet.create({
   },
   pitch: {
     width: '100%',
-    aspectRatio: 2/3,
+    aspectRatio: 1,
     backgroundColor: '#4a8',
     position: 'relative',
   },
@@ -238,7 +253,7 @@ const styles = StyleSheet.create({
   },
   playerText: {
     color: '#000',
-    fontSize: 16,
+    fontSize: 10,
     fontWeight: 'bold',
   },
   selectedPlayer: {


### PR DESCRIPTION
## Summary
- shrink pitch area in `FormationPicker`
- show player names instead of numbers
- expose formation data to parent via props
- add Home/Away toggle on squad screen
- persist formations per team

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486b75eef08332807b12309f014f57