### PR TITLE
Improve formation size selector and player cards

### DIFF
--- a/app/squad/[id]/index.tsx
+++ b/app/squad/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   ScrollView,
   Text,
@@ -6,7 +6,13 @@ import {
   Pressable,
   View,
 } from 'react-native';
-import FormationPicker, { Player, Position, initialPlayers, initialPositions } from '@/components/FormationPicker';
+import FormationPicker, {
+  Player,
+  Position,
+  initialPlayers,
+  formationPositions,
+  initialPositions,
+} from '@/components/FormationPicker';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function SquadScreen() {
@@ -14,9 +20,12 @@ export default function SquadScreen() {
   const squadId = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
 
+  const [playerCount, setPlayerCount] = useState(11);
+
   const [activeTeam, setActiveTeam] = useState<'Home' | 'Away'>('Home');
   const [homeData, setHomeData] = useState({ players: initialPlayers, positions: initialPositions });
   const [awayData, setAwayData] = useState({ players: initialPlayers, positions: initialPositions });
+  const [showDropdown, setShowDropdown] = useState(false);
 
   const handleChange = (data: { players: Player[]; positions: Position[] }) => {
     if (activeTeam === 'Home') {
@@ -26,25 +35,48 @@ export default function SquadScreen() {
     }
   };
 
+  useEffect(() => {
+    const formation = formationPositions[playerCount];
+    const players = initialPlayers.slice(0, playerCount);
+    setHomeData({ players, positions: formation });
+    setAwayData({ players, positions: formation });
+  }, [playerCount]);
+
   const currentData = activeTeam === 'Home' ? homeData : awayData;
 
   return (
     <ScrollView
       contentContainerStyle={styles.container}
       showsVerticalScrollIndicator={false}>
-      <View style={styles.toggleContainer}>
-        <Pressable
-          onPress={() => setActiveTeam('Home')}
-          style={[styles.toggleButton, activeTeam === 'Home' && styles.toggleButtonActive]}
-        >
-          <Text style={[styles.toggleText, activeTeam === 'Home' && styles.toggleTextActive]}>Home</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => setActiveTeam('Away')}
-          style={[styles.toggleButton, activeTeam === 'Away' && styles.toggleButtonActive]}
-        >
-          <Text style={[styles.toggleText, activeTeam === 'Away' && styles.toggleTextActive]}>Away</Text>
-        </Pressable>
+      <View style={styles.selectionRow}>
+        <View style={styles.toggleContainer}>
+          <Pressable
+            onPress={() => setActiveTeam('Home')}
+            style={[styles.toggleButton, activeTeam === 'Home' && styles.toggleButtonActive]}
+          >
+            <Text style={[styles.toggleText, activeTeam === 'Home' && styles.toggleTextActive]}>Home</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setActiveTeam('Away')}
+            style={[styles.toggleButton, activeTeam === 'Away' && styles.toggleButtonActive]}
+          >
+            <Text style={[styles.toggleText, activeTeam === 'Away' && styles.toggleTextActive]}>Away</Text>
+          </Pressable>
+        </View>
+        <View style={styles.dropdownContainer}>
+          <Pressable onPress={() => setShowDropdown(!showDropdown)} style={styles.dropdownToggle}>
+            <Text style={styles.toggleText}>{playerCount} Players ▾</Text>
+          </Pressable>
+          {showDropdown && (
+            <View style={styles.dropdownMenu}>
+              {[5,6,7,8,9,10,11].map(n => (
+                <Pressable key={n} onPress={() => {setPlayerCount(n); setShowDropdown(false);}} style={styles.dropdownOption}>
+                  <Text style={styles.toggleText}>{n} Players</Text>
+                </Pressable>
+              ))}
+            </View>
+          )}
+        </View>
       </View>
       <FormationPicker
         players={currentData.players}
@@ -69,8 +101,8 @@ const styles = StyleSheet.create({
   },
   toggleContainer: {
     flexDirection: 'row',
-    alignSelf: 'center',
-    marginBottom: 16,
+    flexGrow: 1,
+    justifyContent: 'center',
     borderRadius: 4,
     overflow: 'hidden',
     borderWidth: 1,
@@ -90,5 +122,35 @@ const styles = StyleSheet.create({
   },
   toggleTextActive: {
     color: '#08111c',
+  },
+  selectionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  dropdownContainer: {
+    marginLeft: 'auto',
+    zIndex: 20,
+  },
+  dropdownToggle: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#fff',
+    borderRadius: 4,
+  },
+  dropdownMenu: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    backgroundColor: '#08111c',
+    borderColor: '#fff',
+    borderWidth: 1,
+    zIndex: 30,
+  },
+  dropdownOption: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
   },
 });

--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, StyleSheet, Platform, Dimensions, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Platform, Dimensions, TouchableOpacity, Image } from 'react-native';
 import {
   GestureHandlerRootView,
   PanGestureHandler,
@@ -14,7 +14,7 @@ import Animated,
   useAnimatedGestureHandler,
 } from 'react-native-reanimated';
 
-const POSITION_SIZE = 40;
+const POSITION_SIZE = 60;
 const SPRING_CONFIG = {
   damping: 20,
   stiffness: 200,
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
   },
   positionLabel: {
     color: '#fff',
-    fontSize: 12,
+    fontSize: 14,
     fontWeight: 'bold',
     textShadowColor: 'rgba(0,0,0,0.5)',
     textShadowOffset: { width: 1, height: 1 },
@@ -68,13 +68,14 @@ const styles = StyleSheet.create({
     width: POSITION_SIZE,
     height: POSITION_SIZE,
     borderRadius: POSITION_SIZE / 2,
+    overflow: 'hidden',
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#fff',
   },
   playerText: {
     color: '#000',
-    fontSize: 10,
+    fontSize: 12,
     fontWeight: 'bold',
   },
   selectedPlayer: {
@@ -86,6 +87,12 @@ const styles = StyleSheet.create({
     borderColor: '#007AFF',
     borderWidth: 2,
     backgroundColor: 'rgba(0,122,255,0.1)',
+  },
+  playerCardImage: {
+    ...StyleSheet.absoluteFillObject,
+    width: '100%',
+    height: '100%',
+    resizeMode: 'contain',
   },
 });
 
@@ -105,35 +112,113 @@ export interface Position {
   player?: Player;
 }
 
-type PositionId = 'GK' | 'LB' | 'LCB' | 'RCB' | 'RB' | 'DM' | 'LM' | 'RM' | 'AM' | 'CF1' | 'CF2';
+type PositionId =
+  | 'GK'
+  | 'LB'
+  | 'LCB'
+  | 'RCB'
+  | 'RB'
+  | 'CB'
+  | 'DM'
+  | 'CM'
+  | 'LM'
+  | 'RM'
+  | 'AM'
+  | 'LW'
+  | 'RW'
+  | 'CF'
+  | 'CF1'
+  | 'CF2';
 
 export const initialPlayers: Player[] = [
-  { id: '1', name: 'Player 1', number: '1' },
-  { id: '2', name: 'Player 2', number: '2' },
-  { id: '3', name: 'Player 3', number: '3' },
-  { id: '4', name: 'Player 4', number: '4' },
-  { id: '5', name: 'Player 5', number: '5' },
-  { id: '6', name: 'Player 6', number: '6' },
-  { id: '7', name: 'Player 7', number: '7' },
-  { id: '8', name: 'Player 8', number: '8' },
-  { id: '9', name: 'Player 9', number: '9' },
-  { id: '10', name: 'Player 10', number: '10' },
-  { id: '11', name: 'Player 11', number: '11' },
+  { id: '1', name: 'Andy', number: 'Andy' },
+  { id: '2', name: 'Tom', number: 'Tom' },
+  { id: '3', name: 'Clem', number: 'Clem' },
+  { id: '4', name: 'Russ', number: 'Russ' },
+  { id: '5', name: 'Vinny', number: 'Vinny' },
+  { id: '6', name: 'Max', number: 'Max' },
+  { id: '7', name: 'Oscar', number: 'Oscar' },
+  { id: '8', name: 'Ben', number: 'Ben' },
+  { id: '9', name: 'Luke', number: 'Luke' },
+  { id: '10', name: 'Sam', number: 'Sam' },
+  { id: '11', name: 'Theo', number: 'Theo' },
 ];
 
-export const initialPositions: Position[] = [
-  { id: 'GK', label: 'GK', x: 50, y: 90 },
-  { id: 'LB', label: 'LB', x: 20, y: 70 },
-  { id: 'LCB', label: 'CB', x: 35, y: 70 },
-  { id: 'RCB', label: 'CB', x: 65, y: 70 },
-  { id: 'RB', label: 'RB', x: 80, y: 70 },
-  { id: 'DM', label: 'DM', x: 50, y: 50 },
-  { id: 'LM', label: 'LM', x: 20, y: 40 },
-  { id: 'RM', label: 'RM', x: 80, y: 40 },
-  { id: 'AM', label: 'AM', x: 50, y: 30 },
-  { id: 'CF1', label: 'CF', x: 35, y: 20 },
-  { id: 'CF2', label: 'CF', x: 65, y: 20 },
-];
+export const formationPositions: Record<number, Position[]> = {
+  5: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 30 },
+  ],
+  6: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LCB', label: 'CB', x: 40, y: 70 },
+    { id: 'RCB', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 30 },
+  ],
+  7: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LCB', label: 'CB', x: 40, y: 70 },
+    { id: 'RCB', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 25, y: 55 },
+    { id: 'CM', label: 'CM', x: 50, y: 55 },
+    { id: 'RM', label: 'RM', x: 75, y: 55 },
+    { id: 'CF', label: 'CF', x: 50, y: 35 },
+  ],
+  8: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 30 },
+  ],
+  9: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'CM', label: 'CM', x: 40, y: 55 },
+    { id: 'DM', label: 'DM', x: 60, y: 60 },
+    { id: 'LW', label: 'LW', x: 30, y: 40 },
+    { id: 'CF', label: 'CF', x: 50, y: 35 },
+    { id: 'RW', label: 'RW', x: 70, y: 40 },
+  ],
+ 10: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'LCB', label: 'CB', x: 40, y: 70 },
+    { id: 'RCB', label: 'CB', x: 60, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF1', label: 'CF', x: 45, y: 30 },
+    { id: 'CF2', label: 'CF', x: 55, y: 30 },
+  ],
+ 11: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'LCB', label: 'CB', x: 35, y: 70 },
+    { id: 'RCB', label: 'CB', x: 65, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'DM', label: 'DM', x: 50, y: 50 },
+    { id: 'LM', label: 'LM', x: 20, y: 40 },
+    { id: 'RM', label: 'RM', x: 80, y: 40 },
+    { id: 'AM', label: 'AM', x: 50, y: 30 },
+    { id: 'CF1', label: 'CF', x: 35, y: 20 },
+    { id: 'CF2', label: 'CF', x: 65, y: 20 },
+  ],
+};
+
+export const initialPositions: Position[] = formationPositions[11];
+
 
 interface PlayerDotProps {
   player: Player;
@@ -217,7 +302,8 @@ const PlayerDot = React.memo<PlayerDotProps>(({
           animatedStyle,
         ]}
       >
-        <Text numberOfLines={1} style={styles.playerText}>{player.number}</Text>
+        <Image source={require('@/assets/images/player-card.png')} style={styles.playerCardImage} />
+        <Text numberOfLines={1} style={styles.playerText}>{player.name}</Text>
       </AnimatedView>
     </PanGestureHandler>
   );
@@ -266,7 +352,13 @@ const PositionDot = React.memo<PositionDotProps>(({ position, isDropTarget, isSe
           isSelected={isSelected}
         />
       ) : (
-        <Text style={styles.positionLabel}>{position.label}</Text>
+        <>
+          <Image
+            source={require('@/assets/images/player-card.png')}
+            style={styles.playerCardImage}
+          />
+          <Text style={styles.positionLabel}>{position.label}</Text>
+        </>
       )}
     </Animated.View>
   );


### PR DESCRIPTION
## Summary
- enlarge player and position cards in `FormationPicker`
- display card images on empty pitch positions
- show player names instead of numbers
- center Home/Away toggle and move player count dropdown to the right
- raise dropdown z-index so it isn't hidden

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a257a0688332b769a960bea7a085