### PR TITLE
Fix dropdown issues

### DIFF
--- a/app/squad/[id]/index.tsx
+++ b/app/squad/[id]/index.tsx
@@ -80,7 +80,7 @@ export default function SquadScreen() {
                 >
                   <Text style={styles.toggleText}>{n} Players</Text>
                 </Pressable>
-              ))
+              ))}
             </View>
           )}
         </View>
@@ -130,17 +130,20 @@ const styles = StyleSheet.create({
   },
   toggleTextActive: {
     color: '#08111c',
-  },  selectionRow: {
+  },
+  selectionRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 16,
     position: 'relative',
     elevation: 999,
+    zIndex: 999,
   },
   dropdownContainer: {
     marginLeft: 'auto',
     elevation: 1000,
+    zIndex: 1000,
   },
   dropdownToggle: {
     paddingVertical: 6,
@@ -159,6 +162,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     minWidth: '100%', // At least as wide as the toggle
     elevation: 1001,
+    zIndex: 1001,
   },
   dropdownOption: {
     paddingHorizontal: 12,


### PR DESCRIPTION
## Summary
- fix missing closing bracket in dropdown map
- add zIndex to dropdown styles so dropdown appears above the pitch

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493ee341d883329e068e0c35bfca3e