### PR TITLE
Fix pointer events on pitch image

### DIFF
--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -119,6 +119,7 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
         <Image
           source={require('@/assets/images/pitch.png')}
           style={[styles.pitchImage, { resizeMode: 'contain' }]}
+          pointerEvents="none"
         />
       </View>
       <View style={styles.playerList}>


### PR DESCRIPTION
## Summary
- prevent the formation pitch image from catching touches by disabling pointer events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494108c72483329baca83718a79fba