### PR TITLE
Add dynamic formations

### DIFF
--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -54,14 +54,93 @@ export const initialPlayers: Player[] = [
   { id: '11', name: 'Jack', number: '11' }
 ];
 
+// Formations for 5v5 up to 11v11. The x/y coordinates are percentages
+// relative to the pitch image. These provide a simple layout for each
+// formation which will be shown when the player count changes.
 export const formationPositions: Record<number, Position[]> = {
-  5: initialPositions,
-  6: initialPositions,
-  7: initialPositions,
-  8: initialPositions,
-  9: initialPositions,
-  10: initialPositions,
-  11: initialPositions
+  // 5-a-side: 1-2-1-1
+  5: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 6-a-side: 2-2-1
+  6: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 7-a-side: 2-3-1
+  7: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 20, y: 55 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 80, y: 55 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 8-a-side: 3-3-1
+  8: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 9-a-side: 3-2-3
+  9: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'CM', label: 'CM', x: 40, y: 55 },
+    { id: 'DM', label: 'DM', x: 60, y: 60 },
+    { id: 'LW', label: 'LW', x: 25, y: 25 },
+    { id: 'CF', label: 'CF', x: 50, y: 20 },
+    { id: 'RW', label: 'RW', x: 75, y: 25 },
+  ],
+
+  // 10-a-side: 4-3-2
+  10: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 15, y: 70 },
+    { id: 'CB1', label: 'CB', x: 35, y: 70 },
+    { id: 'CB2', label: 'CB', x: 65, y: 70 },
+    { id: 'RB', label: 'RB', x: 85, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF1', label: 'CF', x: 40, y: 25 },
+    { id: 'CF2', label: 'CF', x: 60, y: 25 },
+  ],
+
+  // 11-a-side: 4-1-2-1-2
+  11: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'DM', label: 'DM', x: 50, y: 60 },
+    { id: 'LM', label: 'LM', x: 30, y: 45 },
+    { id: 'RM', label: 'RM', x: 70, y: 45 },
+    { id: 'AM', label: 'AM', x: 50, y: 35 },
+    { id: 'CF1', label: 'CF', x: 40, y: 20 },
+    { id: 'CF2', label: 'CF', x: 60, y: 20 },
+  ],
 };
 
 const styles = StyleSheet.create({
@@ -79,6 +158,21 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     position: 'absolute',
+  },
+  positionNode: {
+    position: 'absolute',
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#4CAF50',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  positionText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+    textAlign: 'center',
   },
   playerList: {
     padding: 10,
@@ -113,6 +207,26 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
   positions = initialPositions,
   onChange 
 }) => {
+  const playerNodes = positions.map((pos, index) => {
+    const player = players[index];
+    return (
+      <View
+        key={pos.id}
+        style={[
+          styles.positionNode,
+          {
+            left: `${pos.x}%`,
+            top: `${pos.y}%`,
+            marginLeft: -20,
+            marginTop: -20,
+          },
+        ]}
+      >
+        <Text style={styles.positionText}>{player ? player.name : pos.label}</Text>
+      </View>
+    );
+  });
+
   return (
     <View style={styles.container}>
       <View style={styles.pitch}>
@@ -121,9 +235,10 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
           style={[styles.pitchImage, { resizeMode: 'contain' }]}
           pointerEvents="none"
         />
+        {playerNodes}
       </View>
       <View style={styles.playerList}>
-        {players.slice(0, positions?.length || players.length).map(player => (
+        {players.slice(0, positions?.length || players.length).map((player) => (
           <Pressable key={player.id} style={styles.playerItem}>
             <Text style={styles.playerName}>{player.name}</Text>
           </Pressable>


### PR DESCRIPTION
## Summary
- show football formation on the pitch based on player count
- map player dropdown to formation positions

## Testing
- `npm test` *(fails: coverage threshold unmet and some tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6849531cd420833284cec7de4050c342