### PR TITLE
Add droppable formation nodes

### DIFF
--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, Platform, Pressable } from 'react-native';
+import { DraxView } from 'react-native-drax';
 
 // Types and interfaces
 export interface Player {
@@ -54,14 +55,93 @@ export const initialPlayers: Player[] = [
   { id: '11', name: 'Jack', number: '11' }
 ];
 
+// Formations for 5v5 up to 11v11. The x/y coordinates are percentages
+// relative to the pitch image. These provide a simple layout for each
+// formation which will be shown when the player count changes.
 export const formationPositions: Record<number, Position[]> = {
-  5: initialPositions,
-  6: initialPositions,
-  7: initialPositions,
-  8: initialPositions,
-  9: initialPositions,
-  10: initialPositions,
-  11: initialPositions
+  // 5-a-side: 1-2-1-1
+  5: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 6-a-side: 2-2-1
+  6: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 7-a-side: 2-3-1
+  7: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 20, y: 55 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 80, y: 55 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 8-a-side: 3-3-1
+  8: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+
+  // 9-a-side: 3-2-3
+  9: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'CM', label: 'CM', x: 40, y: 55 },
+    { id: 'DM', label: 'DM', x: 60, y: 60 },
+    { id: 'LW', label: 'LW', x: 25, y: 25 },
+    { id: 'CF', label: 'CF', x: 50, y: 20 },
+    { id: 'RW', label: 'RW', x: 75, y: 25 },
+  ],
+
+  // 10-a-side: 4-3-2
+  10: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 15, y: 70 },
+    { id: 'CB1', label: 'CB', x: 35, y: 70 },
+    { id: 'CB2', label: 'CB', x: 65, y: 70 },
+    { id: 'RB', label: 'RB', x: 85, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF1', label: 'CF', x: 40, y: 25 },
+    { id: 'CF2', label: 'CF', x: 60, y: 25 },
+  ],
+
+  // 11-a-side: 4-1-2-1-2
+  11: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'DM', label: 'DM', x: 50, y: 60 },
+    { id: 'LM', label: 'LM', x: 30, y: 45 },
+    { id: 'RM', label: 'RM', x: 70, y: 45 },
+    { id: 'AM', label: 'AM', x: 50, y: 35 },
+    { id: 'CF1', label: 'CF', x: 40, y: 20 },
+    { id: 'CF2', label: 'CF', x: 60, y: 20 },
+  ],
 };
 
 const styles = StyleSheet.create({
@@ -80,13 +160,29 @@ const styles = StyleSheet.create({
     height: '100%',
     position: 'absolute',
   },
+  positionNode: {
+    position: 'absolute',
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: '#4CAF50',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  positionText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
   playerList: {
     padding: 10,
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 10,
     justifyContent: 'center',
-  },  playerItem: {
+  },
+  playerItem: {
     backgroundColor: '#fff',
     padding: 10,
     borderRadius: 8,
@@ -113,6 +209,26 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
   positions = initialPositions,
   onChange 
 }) => {
+  const playerNodes = positions.map((pos) => {
+    return (
+      <DraxView
+        key={pos.id}
+        style={[
+          styles.positionNode,
+          {
+            left: `${pos.x}%`,
+            top: `${pos.y}%`,
+            marginLeft: -30,
+            marginTop: -30,
+          },
+        ]}
+        onReceiveDragDrop={() => {}}
+      >
+        <Text style={styles.positionText}>{pos.label}</Text>
+      </DraxView>
+    );
+  });
+
   return (
     <View style={styles.container}>
       <View style={styles.pitch}>
@@ -121,9 +237,10 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
           style={[styles.pitchImage, { resizeMode: 'contain' }]}
           pointerEvents="none"
         />
+        {playerNodes}
       </View>
       <View style={styles.playerList}>
-        {players.slice(0, positions?.length || players.length).map(player => (
+        {players.slice(0, positions?.length || players.length).map((player) => (
           <Pressable key={player.id} style={styles.playerItem}>
             <Text style={styles.playerName}>{player.name}</Text>
           </Pressable>


### PR DESCRIPTION
## Summary
- make formation positions droppable using `react-native-drax`
- display role labels instead of player names
- enlarge formation nodes

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849531cd420833284cec7de4050c342