### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/squad/[id]/index.tsx
+++ b/app/squad/[id]/index.tsx
@@ -8,6 +8,7 @@ import {
   Pressable,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { DraxProvider } from 'react-native-drax';
 import FormationPicker, {
   Player,
@@ -49,14 +50,16 @@ export default function SquadScreen() {
 
   return (
     <DraxProvider>
-      <ScrollView
-        contentContainerStyle={styles.container}
-        showsVerticalScrollIndicator={false}>
-        <View style={styles.selectionRow}>
-          <View style={styles.toggleContainer}>
-            <Pressable
-              onPress={() => setActiveTeam('Home')}
-              style={[styles.toggleButton, activeTeam === 'Home' && styles.toggleButtonActive]}
+      <SafeAreaView style={{ flex: 1 }}>
+        <ScrollView
+          contentContainerStyle={styles.container}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.selectionRow}>
+            <View style={styles.toggleContainer}>
+              <Pressable
+                onPress={() => setActiveTeam('Home')}
+                style={[styles.toggleButton, activeTeam === 'Home' && styles.toggleButtonActive]}
             >
               <Text style={[styles.toggleText, activeTeam === 'Home' && styles.toggleTextActive]}>Home</Text>
             </Pressable>
@@ -94,7 +97,8 @@ export default function SquadScreen() {
           positions={currentData.positions}
           onChange={handleChange}
         />
-      </ScrollView>
+        </ScrollView>
+      </SafeAreaView>
     </DraxProvider>
   );
 }
@@ -102,6 +106,7 @@ export default function SquadScreen() {
 const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
+    flex: 1,
     backgroundColor: '#08111c',
     padding: 16,
     position: 'relative',

--- a/components/FormationPicker.tsx
+++ b/components/FormationPicker.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, Platform, Pressable } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Platform,
+  Pressable,
+  useWindowDimensions,
+} from 'react-native';
 import { DraxView } from 'react-native-drax';
 
 // Types and interfaces
@@ -141,9 +149,6 @@ const styles = StyleSheet.create({
   },
   positionNode: {
     position: 'absolute',
-    width: 60,
-    height: 60,
-    borderRadius: 30,
     backgroundColor: '#4CAF50',
     justifyContent: 'center',
     alignItems: 'center',
@@ -165,6 +170,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 10,
     borderRadius: 8,
+    minWidth: '45%',
+    alignItems: 'center',
+    marginBottom: 8,
     ...Platform.select({
       ios: {
         shadowColor: '#000',
@@ -188,16 +196,21 @@ const FormationPicker: React.FC<FormationPickerProps> = ({
   positions = initialPositions,
   onChange,
 }) => {
+  const { width } = useWindowDimensions();
+  const nodeSize = Math.max(40, width * 0.12);
   const playerNodes = positions.map((pos) => (
     <DraxView
       key={pos.id}
       style={[
         styles.positionNode,
         {
+          width: nodeSize,
+          height: nodeSize,
+          borderRadius: nodeSize / 2,
           left: `${pos.x}%`,
           top: `${pos.y}%`,
-          marginLeft: -30,
-          marginTop: -30,
+          marginLeft: -nodeSize / 2,
+          marginTop: -nodeSize / 2,
         },
       ]}
       onReceiveDragDrop={() => {}}

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -7,6 +7,9 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  useWindowDimensions,
 } from 'react-native';
 import { useUserProfile, ProfileData } from './UserProfileContext';
 
@@ -19,6 +22,7 @@ export default function UserProfileModal() {
   const [location, setLocation] = useState('');
   const [primary, setPrimary] = useState('');
   const [secondary, setSecondary] = useState('');
+  const { width } = useWindowDimensions();
 
   // Show modal if no profile, or allow editing if requested
   useEffect(() => {
@@ -84,6 +88,7 @@ export default function UserProfileModal() {
       padding: 24,
       width: '100%',
       maxWidth: 400,
+      alignSelf: 'center',
     },
     title: {
       color: '#fff',
@@ -147,7 +152,18 @@ export default function UserProfileModal() {
   return (
     <Modal visible={visible} transparent animationType="slide">
       <View style={styles.overlay}>
-        <ScrollView contentContainerStyle={styles.modalContent} testID="modal-content">
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={{ width: '100%' }}
+        >
+          <ScrollView
+            contentContainerStyle={[
+              styles.modalContent,
+              { maxWidth: Math.min(width - 40, 400) },
+            ]}
+            testID="modal-content"
+            keyboardShouldPersistTaps="handled"
+          >
           <Text style={styles.title}>Welcome! Tell us about you</Text>
           <TextInput
             style={styles.input}
@@ -170,7 +186,8 @@ export default function UserProfileModal() {
           <TouchableOpacity style={styles.saveButton} onPress={saveProfile}>
             <Text style={styles.saveButtonText}>Save</Text>
           </TouchableOpacity>
-        </ScrollView>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </View>
     </Modal>
   );


### PR DESCRIPTION
## Summary
- add KeyboardAvoidingView and responsive width to `UserProfileModal`
- wrap squad screen in `SafeAreaView`
- size formation nodes and player list responsively in `FormationPicker`

## Testing
- `npm test` *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68496d6cd7188332817f393e8d4d9afa