### PR TITLE
Fix FormationPicker exports

### DIFF
--- a/components/FormationPicker/index.ts
+++ b/components/FormationPicker/index.ts
@@ -1,3 +1,10 @@
 // components/FormationPicker/index.ts
+// Explicitly re-export the native implementation so that TypeScript
+// correctly resolves both the default component and all named exports.
 export { default } from './FormationPicker';
-export * from './FormationPicker';
+export {
+  initialPlayers,
+  initialPositions,
+  formationPositions,
+} from './FormationPicker';
+export type { Player, Position } from './FormationPicker';


### PR DESCRIPTION
## Summary
- re-export named utilities from `FormationPicker` explicitly so TypeScript resolves them correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a00666f808332ae53d6346fb71970