### PR TITLE
Fix header and tab bar safe areas

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,8 +1,10 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function TabLayout() {
+  const insets = useSafeAreaInsets();
   return (
     <Tabs
       screenOptions={{
@@ -12,8 +14,8 @@ export default function TabLayout() {
           backgroundColor: '#1a1a2e',
           borderTopColor: '#333',
           borderTopWidth: 1,
-          height: 60,
-          paddingBottom: 8,
+          height: 60 + insets.bottom,
+          paddingBottom: insets.bottom + 8,
           paddingTop: 8,
         },
         tabBarLabelStyle: {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import 'react-native-gesture-handler';
 import { Platform } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { DraxProvider } from 'react-native-drax';
 import Header from '@/components/Header';
@@ -17,20 +18,22 @@ const SafeDraxProvider = Platform.OS === 'web'
 export default function RootLayout() {
   const app = (
     <SafeDraxProvider>
-      <UserProfileProvider>
-        <StatusBar style="light" backgroundColor="#1a1a2e" />
-        <UserProfileModal />
-        <Stack
-          screenOptions={{
-            header: () => <Header />,
-            contentStyle: {
-              backgroundColor: '#0f0f23',
-            },
-          }}
-        >
-          <Stack.Screen name="(tabs)" options={{ headerShown: true }} />
-        </Stack>
-      </UserProfileProvider>
+      <SafeAreaProvider>
+        <UserProfileProvider>
+          <StatusBar style="light" backgroundColor="#1a1a2e" />
+          <UserProfileModal />
+          <Stack
+            screenOptions={{
+              header: () => <Header />,
+              contentStyle: {
+                backgroundColor: '#0f0f23',
+              },
+            }}
+          >
+            <Stack.Screen name="(tabs)" options={{ headerShown: true }} />
+          </Stack>
+        </UserProfileProvider>
+      </SafeAreaProvider>
     </SafeDraxProvider>
   );
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, TouchableOpacity, StyleSheet, StatusBar, Image } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter, usePathname, useNavigation } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -7,6 +8,7 @@ const Header = () => {
   const router = useRouter();
   const pathname = usePathname();
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
   const [currentPath, setCurrentPath] = useState(pathname);
 
   useEffect(() => {
@@ -32,7 +34,7 @@ const Header = () => {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top }]}>
       <View style={styles.header}>
         {/* Left side - Back button and Logo */}
         <View style={styles.leftSection}>
@@ -66,7 +68,7 @@ const Header = () => {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: '#08101d',
-    paddingTop: StatusBar.currentHeight || 28,
+    paddingTop: 0,
   },
   header: {
     height: 35,


### PR DESCRIPTION
## Summary
- use SafeAreaInsets in header to avoid top overlap
- integrate bottom safe area padding for tab bar
- wrap app with SafeAreaProvider to support insets

## Testing
- `npm test` *(fails: 4 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2dcd1148332995ce43101b0897c