### PR TITLE
Add drag-and-drop squad formation

### DIFF
--- a/components/FormationPicker/PlayerTile.tsx
+++ b/components/FormationPicker/PlayerTile.tsx
@@ -1,0 +1,47 @@
+import React, { forwardRef } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { DraxView } from 'react-native-drax';
+import type { Player } from './FormationPicker';
+
+interface PlayerTileProps {
+  player: Player;
+}
+
+const PlayerTile = forwardRef<any, PlayerTileProps>(({ player }, ref) => (
+  <DraxView
+    ref={ref}
+    style={styles.container}
+    draggingStyle={styles.dragging}
+    dragReleasedStyle={styles.dragging}
+    hoverDraggingStyle={styles.hoverDragging}
+    longPressDelay={150}
+    dragPayload={player.id}
+  >
+    <Text style={styles.name}>{player.name}</Text>
+  </DraxView>
+));
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    padding: 10,
+    borderRadius: 8,
+    minWidth: '45%',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  dragging: {
+    opacity: 0.2,
+  },
+  hoverDragging: {
+    borderWidth: 1,
+    borderColor: '#fff',
+    transform: [{ scale: 1.05 }],
+  },
+});
+
+export default PlayerTile;

--- a/components/FormationPicker/PositionSlot.tsx
+++ b/components/FormationPicker/PositionSlot.tsx
@@ -1,0 +1,85 @@
+import React, { forwardRef, useState } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { DraxView } from 'react-native-drax';
+import { Ionicons } from '@expo/vector-icons';
+import type { Position } from './FormationPicker';
+
+interface PositionSlotProps {
+  position: Position;
+  nodeSize: number;
+  onReceive: (playerId: string) => void;
+  onRemove: () => void;
+}
+
+const PositionSlot = forwardRef<any, PositionSlotProps>(
+  ({ position, nodeSize, onReceive, onRemove }, ref) => {
+    const [hover, setHover] = useState(false);
+
+    return (
+      <DraxView
+        ref={ref}
+        receptive
+        style={[
+          styles.node,
+          {
+            width: nodeSize,
+            height: nodeSize,
+          borderRadius: nodeSize / 2,
+          left: `${position.x}%`,
+          top: `${position.y}%`,
+          marginLeft: -nodeSize / 2,
+          marginTop: -nodeSize / 2,
+        },
+        hover && styles.nodeHover,
+      ]}
+        onReceiveDragEnter={() => setHover(true)}
+        onReceiveDragExit={() => setHover(false)}
+        onReceiveDragDrop={({ dragged }) => {
+          const payload = dragged?.payload as string;
+          if (payload) onReceive(payload);
+          setHover(false);
+        }}
+      >
+        <Text style={styles.label} numberOfLines={1}>
+          {position.player ? position.player.name : position.label}
+        </Text>
+        {position.player && (
+          <Pressable onPress={onRemove} style={styles.removeButton}>
+            <Ionicons name="close" size={12} color="#fff" />
+          </Pressable>
+        )}
+      </DraxView>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  node: {
+    position: 'absolute',
+    backgroundColor: '#4CAF50',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  nodeHover: {
+    borderWidth: 2,
+    borderColor: '#fff',
+    transform: [{ scale: 1.1 }],
+  },
+  label: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    paddingHorizontal: 2,
+  },
+  removeButton: {
+    position: 'absolute',
+    top: -6,
+    right: -6,
+    backgroundColor: '#333',
+    borderRadius: 8,
+    padding: 2,
+  },
+});
+
+export default PositionSlot;


### PR DESCRIPTION
## Summary
- implement Drax-based drag and drop in `FormationPicker`
- create `PlayerTile` and `PositionSlot` components
- fix ref forwarding so drag views measure correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c011a02ac8332b6f1715f01793cba