### PR TITLE
Add multi-position FormationPicker

### DIFF
--- a/components/FormationPicker/PlayerTile.tsx
+++ b/components/FormationPicker/PlayerTile.tsx
@@ -16,10 +16,11 @@ const DRAG_THRESHOLD_Y = 150;
 
 interface PlayerTileProps {
   player: Player;
-  onDrop: (player: Player) => void;
+  onDrag?: (x: number, y: number) => void;
+  onDrop: (player: Player, x: number, y: number) => void;
 }
 
-const PlayerTile: React.FC<PlayerTileProps> = ({ player, onDrop }) => {
+const PlayerTile: React.FC<PlayerTileProps> = ({ player, onDrag, onDrop }) => {
   const offsetX = useSharedValue(0);
   const offsetY = useSharedValue(0);
 
@@ -34,11 +35,10 @@ const PlayerTile: React.FC<PlayerTileProps> = ({ player, onDrop }) => {
     onActive: (event, ctx) => {
       offsetX.value = ctx.startX + event.translationX;
       offsetY.value = ctx.startY + event.translationY;
+      if (onDrag) runOnJS(onDrag)(event.absoluteX, event.absoluteY);
     },
-    onEnd: () => {
-      if (offsetY.value < -DRAG_THRESHOLD_Y) {
-        runOnJS(onDrop)(player);
-      }
+    onEnd: (event) => {
+      runOnJS(onDrop)(player, event.absoluteX, event.absoluteY);
       offsetX.value = withSpring(0);
       offsetY.value = withSpring(0);
     },

--- a/components/FormationPicker/PositionSlot.tsx
+++ b/components/FormationPicker/PositionSlot.tsx
@@ -1,18 +1,40 @@
 // components/FormationPicker/PositionSlot.tsx
 import React from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet, LayoutRectangle } from 'react-native';
 import type { Player } from './types';
 
 interface PositionSlotProps {
   label: string;
   assignedPlayer: Player | null;
+  highlighted?: boolean;
+  size: number;
+  left: string;
+  top: string;
   onRemove: () => void;
+  onLayout: (layout: LayoutRectangle) => void;
 }
 
-const PositionSlot: React.FC<PositionSlotProps> = ({ label, assignedPlayer, onRemove }) => {
+const PositionSlot: React.FC<PositionSlotProps> = ({
+  label,
+  assignedPlayer,
+  highlighted = false,
+  size,
+  left,
+  top,
+  onRemove,
+  onLayout,
+}) => {
   return (
-    <Pressable style={styles.slot} onPress={onRemove}>
-      <Text style={styles.text}>
+    <Pressable
+      style={[
+        styles.slot,
+        { width: size, height: size, borderRadius: size / 2, left, top },
+        highlighted && styles.highlight,
+      ]}
+      onPress={onRemove}
+      onLayout={(e) => onLayout(e.nativeEvent.layout)}
+    >
+      <Text style={styles.text} numberOfLines={1}>
         {assignedPlayer ? assignedPlayer.name : label}
       </Text>
     </Pressable>
@@ -23,12 +45,14 @@ export default PositionSlot;
 
 const styles = StyleSheet.create({
   slot: {
-    width: 100,
-    height: 100,
+    position: 'absolute',
     backgroundColor: '#4CAF50',
     justifyContent: 'center',
     alignItems: 'center',
-    borderRadius: 50,
+  },
+  highlight: {
+    borderWidth: 2,
+    borderColor: '#fff',
   },
   text: {
     color: '#fff',

--- a/components/FormationPicker/index.ts
+++ b/components/FormationPicker/index.ts
@@ -2,9 +2,5 @@
 // Explicitly re-export the native implementation so that TypeScript
 // correctly resolves both the default component and all named exports.
 export { default } from './FormationPicker';
-export {
-  initialPlayers,
-  initialPositions,
-  formationPositions,
-} from './FormationPicker';
-export type { Player, Position } from './FormationPicker';
+export { formationPositions } from './FormationPicker';
+export type { Player, Position } from './types';

--- a/components/FormationPicker/types.ts
+++ b/components/FormationPicker/types.ts
@@ -3,3 +3,12 @@ export interface Player {
   id: string;
   name: string;
 }
+
+export interface Position {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  player?: Player | null;
+}
+

--- a/components/__tests__/FormationPicker-test.tsx
+++ b/components/__tests__/FormationPicker-test.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import FormationPicker from '../FormationPicker';
+import type { Player } from '../FormationPicker/types';
 
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
 describe('FormationPicker', () => {
   it('renders correctly', () => {
-    const tree = renderer.create(<FormationPicker />).toJSON();
+    const players: Player[] = [
+      { id: '1', name: 'A' },
+      { id: '2', name: 'B' },
+      { id: '3', name: 'C' },
+      { id: '4', name: 'D' },
+      { id: '5', name: 'E' },
+    ];
+    const tree = renderer.create(<FormationPicker players={players} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary
- rebuild FormationPicker to render multiple drop positions and pitch background
- highlight valid drop targets during drag
- update PlayerTile and PositionSlot for new drag/drop callbacks
- adjust exports and tests for new props

## Testing
- `npm ci`
- `npm test` *(fails: Cannot find module '@testing-library/react-hooks' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d61cd7ec0833299192fc135eec1e1