### PR TITLE
Fix FormationPicker slots and player list

### DIFF
--- a/components/FormationPicker/FormationPicker.tsx
+++ b/components/FormationPicker/FormationPicker.tsx
@@ -15,12 +15,80 @@ import type { Player, Position } from './types';
 
 interface FormationPickerProps {
   players: Player[];
-  positions: Position[]; // ✅ reintroduced to match prop usage
+  positions?: Position[];
 }
 
 export const formationPositions: Record<number, Position[]> = {
-  // ... your 5–11-a-side positions (already in place)
-  // unchanged from your latest message
+  5: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+  6: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+  7: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'LM', label: 'LM', x: 20, y: 55 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 80, y: 55 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+  8: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF', label: 'CF', x: 50, y: 25 },
+  ],
+  9: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB', label: 'CB', x: 50, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'CM', label: 'CM', x: 40, y: 55 },
+    { id: 'DM', label: 'DM', x: 60, y: 60 },
+    { id: 'LW', label: 'LW', x: 25, y: 25 },
+    { id: 'CF', label: 'CF', x: 50, y: 20 },
+    { id: 'RW', label: 'RW', x: 75, y: 25 },
+  ],
+  10: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 15, y: 70 },
+    { id: 'CB1', label: 'CB', x: 35, y: 70 },
+    { id: 'CB2', label: 'CB', x: 65, y: 70 },
+    { id: 'RB', label: 'RB', x: 85, y: 70 },
+    { id: 'LM', label: 'LM', x: 30, y: 50 },
+    { id: 'CM', label: 'CM', x: 50, y: 50 },
+    { id: 'RM', label: 'RM', x: 70, y: 50 },
+    { id: 'CF1', label: 'CF', x: 40, y: 25 },
+    { id: 'CF2', label: 'CF', x: 60, y: 25 },
+  ],
+  11: [
+    { id: 'GK', label: 'GK', x: 50, y: 90 },
+    { id: 'LB', label: 'LB', x: 20, y: 70 },
+    { id: 'CB1', label: 'CB', x: 40, y: 70 },
+    { id: 'CB2', label: 'CB', x: 60, y: 70 },
+    { id: 'RB', label: 'RB', x: 80, y: 70 },
+    { id: 'DM', label: 'DM', x: 50, y: 60 },
+    { id: 'LM', label: 'LM', x: 30, y: 45 },
+    { id: 'RM', label: 'RM', x: 70, y: 45 },
+    { id: 'AM', label: 'AM', x: 50, y: 35 },
+    { id: 'CF1', label: 'CF', x: 40, y: 20 },
+    { id: 'CF2', label: 'CF', x: 60, y: 20 },
+  ],
 };
 
 const FormationPicker: React.FC<FormationPickerProps> = ({ players, positions }) => {
@@ -31,14 +99,18 @@ const FormationPicker: React.FC<FormationPickerProps> = ({ players, positions })
   const [slots, setSlots] = useState<Position[]>([]);
   const [highlighted, setHighlighted] = useState<string | null>(null);
   const layouts = useRef<Record<string, LayoutRectangle>>({});
+  const [pitchLayout, setPitchLayout] = useState<LayoutRectangle | null>(null);
 
   useEffect(() => {
-  const formation = formationPositions[players.length] || formationPositions[11];
-  if (!formation) return;
+    const formation =
+      positions && positions.length > 0
+        ? positions
+        : formationPositions[players.length] || formationPositions[11];
+    if (!formation) return;
 
-  setSlots(formation.map((p) => ({ ...p, player: null })));
-  setAvailablePlayers(players);
-  }, [players]);
+    setSlots(formation.map((p) => ({ ...p, player: null })));
+    setAvailablePlayers(players);
+  }, [players, positions]);
 
 
   const findSlotAt = (x: number, y: number) => {
@@ -89,27 +161,40 @@ const FormationPicker: React.FC<FormationPickerProps> = ({ players, positions })
 
   return (
     <View style={styles.container}>
-      <View style={styles.pitch}>
+      <View
+        style={styles.pitch}
+        onLayout={(e) => setPitchLayout(e.nativeEvent.layout)}
+      >
         <Image
           source={require('@/assets/images/pitch.png')}
           style={styles.pitchImage}
           resizeMode="contain"
         />
-        {slots.map((slot) => (
-          <PositionSlot
-            key={slot.id}
-            label={slot.label}
-            assignedPlayer={slot.player || null}
-            highlighted={highlighted === slot.id}
-            size={nodeSize}
-            left={`${slot.x}%`}
-            top={`${slot.y}%`}
-            onRemove={() => handleRemove(slot.id)}
-            onLayout={(layout) => {
-              layouts.current[slot.id] = layout;
-            }}
-          />
-        ))}
+        {slots.map((slot) => {
+          const left =
+            pitchLayout?.width != null
+              ? (slot.x / 100) * pitchLayout.width - nodeSize / 2
+              : 0;
+          const top =
+            pitchLayout?.height != null
+              ? (slot.y / 100) * pitchLayout.height - nodeSize / 2
+              : 0;
+          return (
+            <PositionSlot
+              key={slot.id}
+              label={slot.label}
+              assignedPlayer={slot.player || null}
+              highlighted={highlighted === slot.id}
+              size={nodeSize}
+              left={left}
+              top={top}
+              onRemove={() => handleRemove(slot.id)}
+              onLayout={(layout) => {
+                layouts.current[slot.id] = layout;
+              }}
+            />
+          );
+        })}
       </View>
 
       <View style={styles.list}>
@@ -149,8 +234,8 @@ const styles = StyleSheet.create({
   list: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 10,
     justifyContent: 'center',
+    alignItems: 'flex-start',
     marginBottom: 20,
   },
   resetButton: {

--- a/components/FormationPicker/PlayerTile.tsx
+++ b/components/FormationPicker/PlayerTile.tsx
@@ -67,9 +67,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 12,
     borderRadius: 8,
-    minWidth: width * 0.4,
+    width: width / 3 - 12,
     alignItems: 'center',
     margin: 6,
+    flexGrow: 1,
   },
   name: {
     fontWeight: 'bold',

--- a/components/FormationPicker/PositionSlot.tsx
+++ b/components/FormationPicker/PositionSlot.tsx
@@ -8,8 +8,8 @@ interface PositionSlotProps {
   assignedPlayer: Player | null;
   highlighted?: boolean;
   size: number;
-  left: string;
-  top: string;
+  left: number;
+  top: number;
   onRemove: () => void;
   onLayout: (layout: LayoutRectangle) => void;
 }
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#4CAF50',
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 1,
   },
   highlight: {
     borderWidth: 2,


### PR DESCRIPTION
## Summary
- restore formation positions data
- compute slot coordinates from pitch layout
- refresh available player list when player count changes
- improve player list layout and slot rendering

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_684d66241e108332882d2fd6f820748c